### PR TITLE
Fix the Debye model GibbsFreeEnergyTask

### DIFF
--- a/matmethods/tools/analysis.py
+++ b/matmethods/tools/analysis.py
@@ -64,7 +64,7 @@ def get_debye_model_gibbs(energies, volumes, structure, t_min, t_step, t_max, eo
         (numpy.ndarray, numpy.ndarray): Gibbs free energy , Temperature
         Note: The data points for which the equation of state fitting fails are skipped.
     """
-    temp = np.linspace(t_min, t_max, np.ceil((t_max-t_min)/t_step))
+    temp = np.linspace(t_min, t_max, np.ceil((t_max-t_min)/t_step)+1)
     mass = sum([e.atomic_mass for e in structure.species])
     natoms = structure.composition.num_atoms
 
@@ -79,7 +79,7 @@ def get_debye_model_gibbs(energies, volumes, structure, t_min, t_step, t_max, eo
             continue
         G.append(G_tmp)
         T.append(t)
-    return np.array(G), np.array(T)
+    return G, T
 
 
 def debye_integral(y, integrator):

--- a/matmethods/vasp/firetasks/parse_outputs.py
+++ b/matmethods/vasp/firetasks/parse_outputs.py
@@ -389,10 +389,8 @@ class GibbsFreeEnergyTask(FireTaskBase):
             s = Structure.from_dict(d["calcs_reversed"][-1]["output"]['structure'])
             energies.append(d["calcs_reversed"][-1]["output"]['energy'])
             volumes.append(s.volume)
-            force_constants.append(d["calcs_reversed"][-1]["output"]['force_constants'])
         gibbs_summary_dict["energies"] = energies
         gibbs_summary_dict["volumes"] = volumes
-        gibbs_summary_dict["force_constants"] = force_constants
 
         G, T = None, None
         # use debye model
@@ -405,6 +403,9 @@ class GibbsFreeEnergyTask(FireTaskBase):
 
         # use the phonopy interface
         else:
+            for d in docs:
+                force_constants.append(d["calcs_reversed"][-1]["output"]['force_constants'])
+            gibbs_summary_dict["force_constants"] = force_constants
 
             from matmethods.tools.analysis import get_phonopy_gibbs
 


### PR DESCRIPTION
## Summary

* `vasp.firetasks.parse_outputs.GibbsFreeEnergyTask`
    - Changed the force constants to not be read when using `qha_type="debye_model"`. The Debye model version of the Gibbs free energy task would fail because the force constants were being read from the database documents, but they are not calculated when the Debye model is used and are not in the database.

* `tools.analysis.get_debye_model_gibbs`
    - Changed number of elements in linspace to be `(t_max-t_min)/t_step +1` to have enough elements for a closed loop. I decided to keep `np.linspace` over `np.arange` to better support floating points.
    - Return values for the function were changed to simply be lists rather than NumPy arrays. Arrays are not needed and are not properly converted to lists by `json.dumps`.