### PR TITLE
Fix phonon calculation analysis

### DIFF
--- a/matmethods/vasp/firetasks/parse_outputs.py
+++ b/matmethods/vasp/firetasks/parse_outputs.py
@@ -388,9 +388,13 @@ class GibbsFreeEnergyTask(FireTaskBase):
         for d in docs:
             s = Structure.from_dict(d["calcs_reversed"][-1]["output"]['structure'])
             energies.append(d["calcs_reversed"][-1]["output"]['energy'])
+            if qha_type not in ["debye_model"]:
+                force_constants.append(d["calcs_reversed"][-1]["output"]['force_constants'])
             volumes.append(s.volume)
         gibbs_summary_dict["energies"] = energies
         gibbs_summary_dict["volumes"] = volumes
+        if qha_type not in ["debye_model"]:
+            gibbs_summary_dict["force_constants"] = force_constants
 
         G, T = None, None
         # use debye model
@@ -403,9 +407,6 @@ class GibbsFreeEnergyTask(FireTaskBase):
 
         # use the phonopy interface
         else:
-            for d in docs:
-                force_constants.append(d["calcs_reversed"][-1]["output"]['force_constants'])
-            gibbs_summary_dict["force_constants"] = force_constants
 
             from matmethods.tools.analysis import get_phonopy_gibbs
 


### PR DESCRIPTION
## Summary

* Previous changes moved the `force_constants` processing into another loop for phonon calculations to separate the processing from the Debye model. This broke the phonon post-processing because the `force_constants` were being appended to a list of outputs instead of applied to the ones that already existed. 
* Moving the `force_constants` processing back into the loop fixed this. 
* The solution is perhaps not the most elegant, but matches the style of existing code and has little duplicated code.

## TODO (if any)

* Write tests with mocks for the analysis routines to make sure changing one thing does not break another. This is especially important for analysis tasks that have multiple modes such as phonon calculations and Debye calculations
* Think about how to best check for the `qha_type`. I think we can do better than just checking if the `qha_type` is `"debye_model"` or not.