### PR TITLE
adapt to python 3

### DIFF
--- a/matmethods/vasp/firetasks/write_inputs.py
+++ b/matmethods/vasp/firetasks/write_inputs.py
@@ -306,7 +306,10 @@ class WriteTransmutedStructureIOSet(FireTaskBase):
         for t in self["transformations"]:
             for m in ["advanced_transformations", "defect_transformations",
                       "site_transformations", "standard_transformations"]:
-                mod = __import__("pymatgen.transformations." + m, globals(), locals(), [t], -1)
+                try:
+                    mod = __import__("pymatgen.transformations." + m, globals(), locals(), [t], -1)
+                except ValueError:
+                    mod = __import__("pymatgen.transformations." + m, globals(), locals(), [t], 0)
                 try:
                     t_cls = getattr(mod, t)
                 except AttributeError:


### PR DESCRIPTION
## Summary

Modify `matmethods/vasp/firetasks/write_inputs.py` to adapt to python 3. 

Negative values for level are no longer supported in python 3.3+ (which also changes the default value to 0). I don't know if '0' will also work as what '-1' did in python 2.

* Fix 

ValueError: level must be >= 0, when we use `matmethods/vasp/firetasks/write_inputs.py` in python 3.