### PR TITLE
including the field "scissor" in boltztrap db

### DIFF
--- a/matmethods/vasp/firetasks/parse_outputs.py
+++ b/matmethods/vasp/firetasks/parse_outputs.py
@@ -142,6 +142,15 @@ class BoltztrapToDBTask(FireTaskBase):
 
     optional_params = ["db_file", "hall_doping"]
 
+    def get_intrans(self, btrap_dir):
+        intrans = {}
+        with open(os.path.join(btrap_dir, "boltztrap.intrans"), 'r') as f:
+            for line in f:
+                if "iskip" in line:
+                    intrans["scissor"] = float(line.split(" ")[3])*13.605698066 # converted from Ry to eV
+                    break
+        return intrans
+    
     def run_task(self, fw_spec):
         btrap_dir = os.path.join(os.getcwd(), "boltztrap")
         bta = BoltztrapAnalyzer.from_files(btrap_dir)
@@ -155,6 +164,10 @@ class BoltztrapToDBTask(FireTaskBase):
 
         if not self.get("hall_doping"):
             del d["hall_doping"]
+
+        # from files:
+        intrans = self.get_intrans(btrap_dir)
+        d["scissor"] = intrans["scissor"]
 
         # add the structure
         bandstructure_dir = os.getcwd()


### PR DESCRIPTION
## Summary

reading the value of "scissor" that is applied to the band structure (0.0 is the default). This is needed to differentiate between boltztrap runs with a scissored band structure and the ones with a normal band structure of the same materials. "scissor" is not available through BoltztrapAnalyzer so I added a function to read it from files.